### PR TITLE
Add a day/night  mode

### DIFF
--- a/AliceVolume.install
+++ b/AliceVolume.install
@@ -1,7 +1,7 @@
 {
     "name": "AliceVolume",
     "speakableName": "adjust audio volume",
-    "version": "1.0.14",
+    "version": "1.0.15",
     "icon": "fas fa-volume-up",
     "category": "assistance",
     "author": "lazza",

--- a/AliceVolume.py
+++ b/AliceVolume.py
@@ -61,18 +61,40 @@ class AliceVolume(AliceSkill):
 
 			action = ['set', 'lowered', 'raised']
 
-			self.endDialog(
-				sessionId=sessionId,
-				text=self.randomTalk(text="dialogMessage2", replace=[self.randomTalk(text=action[AliceVolume._ADJUSTED_VOLUME]), spokenLevel[0]])
-			)
+			if sessionId:
+				self.endDialog(
+					sessionId=sessionId,
+					text=self.randomTalk(text="dialogMessage2", replace=[self.randomTalk(text=action[AliceVolume._ADJUSTED_VOLUME]), spokenLevel[0]])
+				)
 
 			AliceVolume._ADJUSTED_VOLUME = 0
 
 
 		else:
-			self.endDialog(
-				sessionId=sessionId,
-				text=self.randomTalk(text="dialogMessage1")
-			)
+			if sessionId:
+				self.endDialog(
+					sessionId=sessionId,
+					text=self.randomTalk(text="dialogMessage1")
+				)
 			AliceVolume._ADJUSTED_VOLUME = 0
 			return self.logError(f'Error with {self.name} configuration. Have you selected the right card ?: {result.stderr}')
+
+
+	def onSleep(self):
+		self.autoAdjustVolume(dayOrNight="night")
+
+	def onWakeup(self):
+		self.autoAdjustVolume(dayOrNight="day")
+
+
+	def autoAdjustVolume(self, dayOrNight: str):
+		if self.getConfig('nightModeVolume'):
+			level = self.getConfig(f'{dayOrNight}TimeLevel')
+			if not level:
+				if dayOrNight == "night":
+					level = "10"
+				else:
+					level = "80"
+
+			self.adjustVolumePi(level=f'{level}%', card=self.getConfig('audioOut'), sessionId="")
+

--- a/config.json.template
+++ b/config.json.template
@@ -15,5 +15,23 @@
 		"dataType": "string",
 		"isSensitive": false,
 		"description": "Manually enter audio port"
+	},
+	"nightTimeLevel": {
+		"defaultValue": "10",
+		"dataType": "string",
+		"isSensitive": false,
+		"description": "Volume down on good night"
+	},
+	"dayTimeLevel": {
+		"defaultValue": "80",
+		"dataType": "string",
+		"isSensitive": false,
+		"description": "Volume up on good morning"
+	},
+	"nightModeVolume": {
+		"defaultValue": false,
+		"dataType": "boolean",
+		"isSensitive": false,
+		"description": "Set new volume when in night mode"
 	}
 }

--- a/instructions/en.md
+++ b/instructions/en.md
@@ -12,6 +12,7 @@ Alternatively increase or decrease the volume with
 
 ## SETUP
 
+
 In the pi's terminal type 
 
  - ```aplay -l```
@@ -33,4 +34,9 @@ a different port than what it detects you can enter the port name into this fiel
 
 Please discuss in discord any additions you find that need added.
 
- 
+### Day / Night mode
+
+With "night mode volume" switch enabled (found in the skill settings)
+
+- Alice will set the volume automatically to the "Day Time Level" when you say "good morning" to alice
+- Alice will set the volume automatically to the "night time level" when you say "good night"


### PR DESCRIPTION
##### Summary

A request from ```@mpbs```. Add a day/night mode  to allow Alice to auto adjust the volume depending on the users onSleep and onWake events

To use  -
- Enable "night mode" (found in the skills settings)
- Enter values you would like for day and night time levels (found in the skills settings) EG : 100
- Say good morning or good night to Alice

Instructions also include these steps 
 
##### What kind of change does this PR introduce?

<!-- Check at least one -->

- [ ] Bugfix
- [x] New feature
- [ ] Refactoring
- [ ] Other, please describe:

##### Does this PR introduce a breaking change?

<!-- Check one -->

- [ ] Yes
- [x] No

<!-- If yes, please describe the path to migrate existing installs to this: -->
###### Migration guide:

<!-- How to migrate from existing Alice's installs -->

##### The PR fulfills these requirements:

- [ ] When resolving/implementing a specific issue, it's referenced in the PR's title (e.g. `fix #xxx` or `implement #xxx`, where "xxx" is the issue number)
- [x] You have tested your changes on the branch you wish to merge
- [x] The changes are working


If adding a **new feature**, the PR's description includes:

- [x] The reason for this new feature to be added
- [x] The use of this new feature
- [ ] If available, a link to an existing feature request ticket


###### Other information: